### PR TITLE
fix the special characters problem such as Chinese characters

### DIFF
--- a/Source/Codaxy.Xlio/IO/XlsxFileReader.cs
+++ b/Source/Codaxy.Xlio/IO/XlsxFileReader.cs
@@ -170,6 +170,13 @@ namespace Codaxy.Xlio.IO
                             sb.Append(t.t);
                         s = sb.ToString();
                     }
+                    else if (ss.r != null)
+                    {
+                        StringBuilder sb = new StringBuilder();
+                        foreach (var t in ss.r)
+                            sb.Append(t.t);
+                        s = sb.ToString();
+                    }
                     else
                         s = String.Empty;
                     sharedStrings.Add(s);


### PR DESCRIPTION
when a cell contains chinese characters, it is necessary to handle the ss.r property to get the real value. Otherwise the cell will be empty (but it does contain value)
